### PR TITLE
Update Camomile module path for 2.0.0

### DIFF
--- a/model.ml
+++ b/model.ml
@@ -13,7 +13,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-open CamomileLibrary
+open Camomile
 open Printf
 
 exception Error of string


### PR DESCRIPTION
Camomile 2.0.0 changed the module path. I might have wanted them to go through a proper deprecation period, or make a compatibility package, or... but it's a very simple change at least.